### PR TITLE
TODO: Submit this after "Convert even more paths to std::filesystem::path" is merged

### DIFF
--- a/colobot-base/src/graphics/engine/particle.cpp
+++ b/colobot-base/src/graphics/engine/particle.cpp
@@ -143,7 +143,7 @@ void CParticle::FlushParticle(int sheet)
 
 
 //! Returns file name of the effect effectNN.png, with NN = number
-std::filesystem::path NameParticle(int num)
+static std::filesystem::path NameParticle(int num)
 {
     switch(num)
     {

--- a/colobot-common/src/common/stringutils.cpp
+++ b/colobot-common/src/common/stringutils.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
@@ -304,9 +305,10 @@ int StrUtils::UTF8CharLength(std::string_view string)
     if (string.empty()) return 0;
 
     int len = UTF8SequenceLength(static_cast<char8_t>(string.front()));
+    assert(len >= 0);
 
     // UTF-8 sequence is not long enough
-    if (string.size() < len) return 0;
+    if (string.size() < static_cast<size_t>(len)) return 0;
 
     // Check continuation bytes
     for (int i = 1; i < len; i++)
@@ -322,12 +324,13 @@ int StrUtils::UTF8StringLength(std::string_view string)
 
     while (!string.empty())
     {
-        auto count = UTF8SequenceLength(static_cast<char8_t>(string.front()));
+        int count = UTF8SequenceLength(static_cast<char8_t>(string.front()));
+        assert(count >= 0);
 
         if (count == 0)
             throw std::invalid_argument("Invalid character");
         
-        if (string.size() < count)
+        if (string.size() < static_cast<size_t>(count))
             throw std::invalid_argument("Invalid character");
         
         for (int i = 1; i < count; i++)


### PR DESCRIPTION
I am opening this to remind myself that I have a branch that depends on str2path

```
/home/cdda/git/colobot/colobot-common/src/common/stringutils.cpp: In function ‘int StrUtils::UTF8CharLength(std::string_view)’:
/home/cdda/git/colobot/colobot-common/src/common/stringutils.cpp:309:23: error: comparison of integer expressions of different signedness: ‘std::basic_string_view<char>::size_type’ 
{aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
  309 |     if (string.size() < len) return 0;
      |         ~~~~~~~~~~~~~~^~~~~
/home/cdda/git/colobot/colobot-common/src/common/stringutils.cpp: In function ‘int StrUtils::UTF8StringLength(std::string_view)’:
/home/cdda/git/colobot/colobot-common/src/common/stringutils.cpp:330:27: error: comparison of integer expressions of different signedness: ‘std::basic_string_view<char>::size_type’ 
{aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
  330 |         if (string.size() < count)
      |             ~~~~~~~~~~~~~~^~~~~~~
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:146:23: error: no previous declaration for ‘std::filesystem::__cxx11::path Gfx::NameParticle(int)’ [-Werror=missing-declarations]
  146 | std::filesystem::path NameParticle(int num)
      |                       ^~~~~~~~~~~~
```